### PR TITLE
profiles: add energy_performance_preference hints to profiles

### DIFF
--- a/profiles/balanced/tuned.conf
+++ b/profiles/balanced/tuned.conf
@@ -12,6 +12,7 @@ cpufreq_conservative=+r
 priority=10
 governor=conservative|powersave
 energy_perf_bias=normal
+energy_performance_preference=balance_performance
 
 [audio]
 timeout=10

--- a/profiles/powersave/tuned.conf
+++ b/profiles/powersave/tuned.conf
@@ -8,6 +8,7 @@ summary=Optimize for low power consumption
 [cpu]
 governor=ondemand|powersave
 energy_perf_bias=powersave|power
+energy_performance_preference=power
 
 [eeepc_she]
 

--- a/profiles/server-powersave/tuned.conf
+++ b/profiles/server-powersave/tuned.conf
@@ -6,6 +6,7 @@
 summary=Optimize for server power savings
 
 [cpu]
+energy_performance_preference=balance_power
 
 [disk]
 

--- a/profiles/throughput-performance/tuned.conf
+++ b/profiles/throughput-performance/tuned.conf
@@ -13,6 +13,7 @@ amd_cpuinfo_regex=model name\s+:.*\bAMD\b
 governor=performance
 energy_perf_bias=performance
 min_perf_pct=100
+energy_performance_preference=performance
 
 # Marvell ThunderX
 [vm.thunderx]


### PR DESCRIPTION
This commit adds 'energy_performance_preference' tunings for some of the premade profiles in TuneD. For more information about energy_performance_preference, see https://www.kernel.org/doc/html/v4.19/admin-guide/pm/intel_pstate.html#energy-vs-performance-hints